### PR TITLE
Use pre for solidity error message.

### DIFF
--- a/app/client/templates/elements/compileContract.html
+++ b/app/client/templates/elements/compileContract.html
@@ -44,7 +44,7 @@
                         <p class="orange">
                             <i class="icon-shield"></i> {{i18n 'wallet.contracts.error.compile'}}
                             <br><br>
-                            <code>{{this}}</code>
+                            <pre>{{this}}</pre>
                         </p>
 
                     {{else}}


### PR DESCRIPTION
This changes enables the `^` symbol in the Solidity error messages to be positioned at the right point. Previously, line breaks were ignored and thus the position of the symbol was incorrect.

Note: I was not able to test this change.