### PR TITLE
add default name in function "addCustomContract"

### DIFF
--- a/app/client/templates/views/contracts.js
+++ b/app/client/templates/views/contracts.js
@@ -22,7 +22,7 @@ var addCustomContract = function(e) {
     var address = $('.modals-add-custom-contract input[name="address"]').hasClass('dapp-error')
             ? ''
             : $('.modals-add-custom-contract input[name="address"]').val(),
-        name = $('.modals-add-custom-contract input.name').val();
+        name = $('.modals-add-custom-contract input.name').val() || TAPi18n.__('wallet.accounts.defaultName');
 
     address = address.toLowerCase();
 


### PR DESCRIPTION
The function _addCustomContract_ used when adding custom contract has no default name.

If someone leaves the field _name_ empty, then he/she cannot edit the name or delete the custom contract directly on the UI because the text under _span.edit-name_ element is then empty string and nowhere to be clicked.