### PR TITLE
Make the wallet span the whole width of the app

### DIFF
--- a/app/client/styles/main.less
+++ b/app/client/styles/main.less
@@ -777,7 +777,7 @@ body {
         }
         
         table {
-            // max-width: @gridWidth * 16;
+            table-layout: fixed;
             
             tr:nth-child(odd) {
                 border-radius: 4px 4px 0 0;
@@ -791,6 +791,7 @@ body {
             td {
                 border-radius: 2px;
                 vertical-align: top;
+                word-wrap: break-word;
 
                 h3 {    
                     margin: 0;
@@ -800,8 +801,8 @@ body {
                     margin: 0;
                     dd {
                         margin-left: 0;
-                        // max-width: 14 * @gridWidth;
                         margin-bottom: @gridHeight;
+                        word-wrap: break-word;
                     }
                 }    
             }

--- a/app/client/styles/main.less
+++ b/app/client/styles/main.less
@@ -50,9 +50,12 @@
 
 
 .dapp-content {
-    padding-bottom: @defaultPaddingVertical*2;
+    padding: @defaultPaddingVertical @defaultPaddingHorizontal*2.5 @defaultPaddingVertical*2;
+    max-width: none;
 
     .dapp-container {
+        max-width: none; 
+
         > h2 {
             margin-bottom: @gridHeight * 1;
         }
@@ -140,6 +143,8 @@ body {
 
 
 .dapp-header {
+    padding-right: @gridWidth * 2;
+    padding-left: @gridWidth * 2;
     background-color: @colorWinBackgroundFocus;
     .background-image(linear-gradient(to bottom,  @colorWinBackgroundFocus 50%, #ddd9d9 90%));
     
@@ -267,7 +272,7 @@ body {
         left: 0;
         right: 0;
         height: @gridHeight * 2;
-        padding: @gridHeight/2 @gridWidth;
+        padding: @gridHeight/2 @gridWidth * 2.5;
         background: @colorWhite;
         .transition(top @animationSpeed);
         // box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
@@ -282,7 +287,7 @@ body {
             width: floor(@gridWidth / 1.5);
             height: floor(@gridWidth / 1.5);
             box-shadow: inset rgba(255, 255, 255, 0.4) 0 1px 1px, inset rgba(0, 0, 0, 0.3) 0 -1px 2px;
-            left: @gridWidth;
+            left: @gridWidth * 2.5;
         }
 
         h1 {
@@ -293,7 +298,7 @@ body {
         
         .account-balance {
             position: absolute;
-            right: @gridWidth;
+            right: @gridWidth * 2;
             top: 7px;
             font-size: 1.2em;
             font-weight: 400;
@@ -772,7 +777,7 @@ body {
         }
         
         table {
-            max-width: @gridWidth * 16;
+            // max-width: @gridWidth * 16;
             
             tr:nth-child(odd) {
                 border-radius: 4px 4px 0 0;
@@ -795,7 +800,7 @@ body {
                     margin: 0;
                     dd {
                         margin-left: 0;
-                        max-width: 14 * @gridWidth;
+                        // max-width: 14 * @gridWidth;
                         margin-bottom: @gridHeight;
                     }
                 }    


### PR DESCRIPTION
Also adjusts the margins so that the close and minimize buttons won’t interfere with the buttons on Mac. Useful for large screens.

![captura de tela 2016-06-02 as 9 55 41 pm](https://cloud.githubusercontent.com/assets/112898/15765720/2fb153b6-290e-11e6-8c09-053c5b17605c.png)
![captura de tela 2016-06-02 as 9 55 49 pm](https://cloud.githubusercontent.com/assets/112898/15765723/33dc9932-290e-11e6-9c18-af0b3d378713.png)
