### PR TITLE
Immediately initialize inputs for `constant` contract functions.

### DIFF
--- a/app/client/templates/elements/executeContract.js
+++ b/app/client/templates/elements/executeContract.js
@@ -130,6 +130,10 @@ var formatOutput = function(val) {
 Template['elements_executeContract_constant'].onCreated(function(){
     var template = this;
 
+    // initialize our input data prior to the first call
+    var inputs = Helpers.addInputValue(template.data.inputs, this);
+    TemplateVar.set('inputs', inputs);
+
     // call the contract functions when data changes and on new blocks
     this.autorun(function() {
         // make reactive to the latest block

--- a/app/client/templates/elements/executeContract.js
+++ b/app/client/templates/elements/executeContract.js
@@ -131,8 +131,9 @@ Template['elements_executeContract_constant'].onCreated(function(){
     var template = this;
 
     // initialize our input data prior to the first call
-    var inputs = Helpers.addInputValue(template.data.inputs, this);
-    TemplateVar.set('inputs', inputs);
+    TemplateVar.set('inputs', template.data.inputs.map(function() {
+        return '';
+    }));
 
     // call the contract functions when data changes and on new blocks
     this.autorun(function() {

--- a/app/client/templates/elements/executeContract.js
+++ b/app/client/templates/elements/executeContract.js
@@ -131,8 +131,8 @@ Template['elements_executeContract_constant'].onCreated(function(){
     var template = this;
 
     // initialize our input data prior to the first call
-    TemplateVar.set('inputs', template.data.inputs.map(function() {
-        return '';
+    TemplateVar.set('inputs', _.map(template.data.inputs, function(input) {
+        return Helpers.addInputValue([input], input, {})[0];
     }));
 
     // call the contract functions when data changes and on new blocks


### PR DESCRIPTION
Since `constant` contract functions automatically run when the
contract is viewed, we must initialize the input data during the
loading phase of the view, otherwise we will call the contract code
with zero arguments. Issue #216