### PR TITLE
Invoke `constant` contract functions with a shallow copy of inputs.

### DIFF
--- a/app/client/templates/elements/executeContract.js
+++ b/app/client/templates/elements/executeContract.js
@@ -140,11 +140,8 @@ Template['elements_executeContract_constant'].onCreated(function(){
         // make reactive to the latest block
         EthBlocks.latest;
 
-        // get args for the constant function
-        var args = TemplateVar.get('inputs') || [];
-
-        // add callback
-        args.push(function(e, r) {
+        // get args for the constant function and add callback
+        var args = TemplateVar.get('inputs').concat(function(e, r) {
             if(!e) {
                 var outputs = [];
                 // single return value


### PR DESCRIPTION
We now append our callback function to a clone of the input data.
Since input data is already initialized, we can drop the `|| []`.

Issue #233.