### PR TITLE
Adds transaction failure message to an event, where transaction is ou…

### DIFF
--- a/app/client/lib/ethereum/observeTransactions.js
+++ b/app/client/lib/ethereum/observeTransactions.js
@@ -327,6 +327,14 @@ observeTransactions = function(){
 
                                     // if still not mined, remove tx
                                     if(!transaction || !transaction.blockNumber) {
+
+                                        var warningText = TAPi18n.__('wallet.transactions.error.outOfGas', {from: Helpers.getAccountNameByAddress(transaction.from), to: Helpers.getAccountNameByAddress(transaction.to)});
+                                        Helpers.eventLogs(warningText);
+                                        GlobalNotification.warning({
+                                            content: warningText,
+                                            duration: 10
+                                        });
+
                                         Transactions.remove(tx._id);
                                         filter.stopWatching();
 


### PR DESCRIPTION
Adds transaction failure message to an event, where transaction is out of tries and is removed from the list. Uses currently available "outOfGas" message body, which seems suitable.

issue: https://github.com/ethereum/mist/issues/931