### PR TITLE
Allowing multi-sig wallet to control transactions that do not send ether

### DIFF
--- a/Wallet.sol
+++ b/Wallet.sol
@@ -238,8 +238,9 @@ contract daylimit is multiowned {
     // METHODS
 
     // constructor - stores initial daily limit and records the present day's index.
-    function daylimit(uint _limit) {
+    function daylimit(uint _limit, bool _alwaysRequireMutliSig) {
         m_dailyLimit = _limit;
+        m_alwaysRequireMutliSig = _alwaysRequireMutliSig;
         m_lastDay = today();
     }
     // (re)sets the daily limit. needs many of the owners to confirm. doesn't alter the amount already spent today.
@@ -261,6 +262,11 @@ contract daylimit is multiowned {
             m_spentToday = 0;
             m_lastDay = today();
         }
+        
+        if (m_alwaysRequireMutliSig) {
+            return false;
+        }
+        
         // check to see if there's enough left - if so, subtract and return true.
         if (m_spentToday + _value >= m_spentToday && m_spentToday + _value <= m_dailyLimit) {
             m_spentToday += _value;
@@ -274,6 +280,7 @@ contract daylimit is multiowned {
     // FIELDS
 
     uint public m_dailyLimit;
+    bool public m_alwaysRequireMutliSig;
     uint public m_spentToday;
     uint public m_lastDay;
 }
@@ -321,8 +328,8 @@ contract Wallet is multisig, multiowned, daylimit {
 
     // constructor - just pass on the owner array to the multiowned and
     // the limit to daylimit
-    function Wallet(address[] _owners, uint _required, uint _daylimit)
-            multiowned(_owners, _required) daylimit(_daylimit) {
+    function Wallet(address[] _owners, uint _required, uint _daylimit, bool _alwaysRequireMultiSig)
+            multiowned(_owners, _required) daylimit(_daylimit, _alwaysRequireMultiSig) {
     }
     
     // kills the contract sending everything to `_to`.

--- a/app/client/lib/ethereum/observeWallets.js
+++ b/app/client/lib/ethereum/observeWallets.js
@@ -653,7 +653,7 @@ observeWallets = function(){
 
                         console.log('Deploying Wallet with following options', newDocument);
 
-                        WalletContract.new(newDocument.owners, newDocument.requiredSignatures, (newDocument.dailyLimit || ethereumConfig.dailyLimitDefault), {
+                        WalletContract.new(newDocument.owners, newDocument.requiredSignatures, (newDocument.dailyLimit || ethereumConfig.dailyLimitDefault), newDocument.requireSigForAllTransactions, {
                             from: newDocument.deployFrom,
                             data: newDocument.code,
                             gas: 3000000,

--- a/app/client/templates/views/account_create.html
+++ b/app/client/templates/views/account_create.html
@@ -37,7 +37,7 @@
             {{#if showSection "multisig"}}
                 <div class="indented-box">
                     <p>{{i18n 'wallet.newWallet.accountType.multisig.text1'}} {{> InlineForm name="multisigSignees" items=multisigSignees value=(TemplateVar.get "multisigSignees")}} {{i18n 'wallet.newWallet.accountType.multisig.text2'}} {{> InlineForm name="dailyLimitAmount" value=defaultDailyLimit}} {{i18n 'wallet.newWallet.accountType.multisig.text3'}}</p>
-                    <p>{{i18n 'wallet.newWallet.accountType.multisig.text4'}} {{> InlineForm name="multisigSignatures" items=multisigSignatures value=(TemplateVar.get "multisigSignatures")}} {{i18n 'wallet.newWallet.accountType.multisig.text5'}}</p>
+                    <p>{{i18n 'wallet.newWallet.accountType.multisig.text4'}} {{> InlineForm name="requireSigForAllTransactions" items=requireSigForAllTransactions value=(TemplateVar.get "requireSigForAllTransactions")}} {{i18n 'wallet.newWallet.accountType.multisig.text4ending'}}  {{> InlineForm name="multisigSignatures" items=multisigSignatures value=(TemplateVar.get "multisigSignatures")}} {{i18n 'wallet.newWallet.accountType.multisig.text5'}}</p>
 
                     <h4>{{i18n 'wallet.newWallet.accountType.multisig.accountOwnersTitle'}}</h4>
 

--- a/app/client/templates/views/account_create.js
+++ b/app/client/templates/views/account_create.js
@@ -17,9 +17,11 @@ Template['views_account_create'].onCreated(function(){
     // number of owners of the account
     var walletId = FlowRouter.getQueryParam('walletId');
     var maxOwners = FlowRouter.getQueryParam('ownersNum');
+    var requireSigForAll = FlowRouter.getQueryParam('requireSigForAll');
     if(maxOwners && Helpers.isWatchOnly(walletId))
         maxOwners++;
     TemplateVar.set('multisigSignees', maxOwners || 3);     
+    TemplateVar.set('requireSigForAllTransactions', requireSigForAll || false);     
 
     // number of required signatures    
     TemplateVar.set('multisigSignatures', Number(FlowRouter.getQueryParam('requiredSignatures')) || 2);   
@@ -195,6 +197,20 @@ Template['views_account_create'].helpers({
 
         return returnArray;
     },
+        /**
+    Get the number of required multisignatures
+
+    @method (multisigSignatures)
+    */
+    'requireSigForAllTransactions': function() {
+        var signees = TemplateVar.get('alwaysRequireMultiSig');
+        var returnArray = []
+        
+        returnArray.push({value:false, text:TAPi18n.__('wallet.newWallet.accountType.multisig.overLimit')});
+        returnArray.push({value:true, text:TAPi18n.__('wallet.newWallet.accountType.multisig.requireForAll')});
+
+        return returnArray;
+    },
     /**
     Is simple checked
 
@@ -323,6 +339,7 @@ Template['views_account_create'].events({
                 balance: '0',
                 dailyLimit: web3.toWei(formValues.dailyLimitAmount, 'ether'),
                 requiredSignatures: formValues.multisigSignatures,
+                requireSigForAllTransactions: formValues.requireSigForAllTransactions,
                 creationBlock: EthBlocks.latest.number,
                 code: code
             });

--- a/app/client/templates/views/account_create.js
+++ b/app/client/templates/views/account_create.js
@@ -198,12 +198,11 @@ Template['views_account_create'].helpers({
         return returnArray;
     },
         /**
-    Get the number of required multisignatures
+    Get the condition that controls when multi-sig is required
 
-    @method (multisigSignatures)
+    @method (requireSigForAllTransactions)
     */
     'requireSigForAllTransactions': function() {
-        var signees = TemplateVar.get('alwaysRequireMultiSig');
         var returnArray = []
         
         returnArray.push({value:false, text:TAPi18n.__('wallet.newWallet.accountType.multisig.overLimit')});
@@ -211,6 +210,7 @@ Template['views_account_create'].helpers({
 
         return returnArray;
     },
+    
     /**
     Is simple checked
 

--- a/app/i18n/wallet.en.i18n.json
+++ b/app/i18n/wallet.en.i18n.json
@@ -206,9 +206,9 @@
                     "text2": "owners. You can send up to",
                     "text3": "ether per day.",
                     "text4": "Any transaction ",
-                    "overLimit": "over that daily limit"
-                    "requireForAll": "including those that do not transfer ether"
-                    "text4ending": "requires the confirmation of"
+                    "overLimit": "over that daily limit",
+                    "requireForAll": "including those that do not transfer ether",
+                    "text4ending": "requires the confirmation of",
                     "text5": "owners.",
                     "accountOwnersTitle": "Account owners",
                     "ownerAddress": "Owner address"

--- a/app/i18n/wallet.en.i18n.json
+++ b/app/i18n/wallet.en.i18n.json
@@ -205,7 +205,10 @@
                     "text1": "This is a joint account controlled by",
                     "text2": "owners. You can send up to",
                     "text3": "ether per day.",
-                    "text4": "Any transaction over that daily limit requires the confirmation of",
+                    "text4": "Any transaction ",
+                    "overLimit": "over that daily limit"
+                    "requireForAll": "including those that do not transfer ether"
+                    "text4ending": "requires the confirmation of"
                     "text5": "owners.",
                     "accountOwnersTitle": "Account owners",
                     "ownerAddress": "Owner address"


### PR DESCRIPTION
I am very new to the code base and don't have it up and running locally.  This is just an example of what I was thinking in this issue: https://github.com/ethereum/meteor-dapp-wallet/issues/282

Originally, I had just intended to submit the contract changes, then I started poking at the UI side as well... 

The way it is now would not be very clean in the UI (and I haven't tested the UI at all).  Another option might be to have another type of multi-sig wallet that does not have a daily limit option in the UI.  The contract could still be the same (as modified below), but the daily limit would be hidden from the user in the UI.  