### PR TITLE
Mist api changes, backwards compatibility

### DIFF
--- a/app/client/lib/helpers/templateHelpers.js
+++ b/app/client/lib/helpers/templateHelpers.js
@@ -37,7 +37,8 @@ Check if in mist and in mist mode
 @method (isMistMode)
 **/
 Template.registerHelper('isMistMode', function(){
-    return (typeof mist !== 'undefined' && mist.mode === 'mist');
+    return (typeof mist !== 'undefined' && mist.mode === 'mist') ||    // old mist api <= 0.8.7
+           (typeof mistMode !== 'undefined' && mistMode === 'mist');   // new mist api >= 0.8.8
 });
 
 /**


### PR DESCRIPTION
Works properly with https://github.com/ethereum/mist/pull/1483 onwards.