### PR TITLE
Set placeholder contract's pragma version using Mist-API

### DIFF
--- a/app/client/lib/appStart.js
+++ b/app/client/lib/appStart.js
@@ -4,11 +4,9 @@ if(location.hostname !== 'localhost' && location.hostname !== '127.0.0.1')
 
 
 // Make sure the example contract code is up to date
-var shortExample = Helpers.getDefaultContractExample().substr(Helpers.getDefaultContractExample().indexOf("\n\n")+2);
-
 var contractSource = localStorage.getItem('contractSource');
 
-if (contractSource && (contractSource.indexOf(shortExample) !== -1 || contractSource === "")) {
+if (contractSource && (contractSource === "" || contractSource.indexOf(Helpers.getDefaultContractExample(true)) !== -1)) {
     localStorage.setItem('contractSource', Helpers.getDefaultContractExample());
 }
  

--- a/app/client/lib/appStart.js
+++ b/app/client/lib/appStart.js
@@ -6,7 +6,10 @@ if(location.hostname !== 'localhost' && location.hostname !== '127.0.0.1')
 // Make sure the example contract code is up to date
 var contractSource = localStorage.getItem('contractSource');
 
-if (contractSource && (contractSource === "" || contractSource.indexOf(Helpers.getDefaultContractExample(true)) !== -1)) {
+if (contractSource  // repopulate placeholder contract if:
+    && (contractSource === ""  // source is empty or
+    || (contractSource.indexOf(Helpers.getDefaultContractExample(true)) !== -1)  // default 'MyContract' exists and
+    && contractSource.split('contract ').length-1 === 1)) {  // 'MyContract' is the only contract
     localStorage.setItem('contractSource', Helpers.getDefaultContractExample());
 }
  

--- a/app/client/lib/appStart.js
+++ b/app/client/lib/appStart.js
@@ -4,9 +4,12 @@ if(location.hostname !== 'localhost' && location.hostname !== '127.0.0.1')
 
 
 // Make sure the example contract code is up to date
-var shortExample = Helpers.defaultContractExample.substr(Helpers.defaultContractExample.indexOf("\n\n")+2);
-if (localStorage.getItem('contractSource') && localStorage.getItem('contractSource').indexOf(shortExample) !== -1) {
-    localStorage.setItem('contractSource', Helpers.defaultContractExample);
+var shortExample = Helpers.getDefaultContractExample().substr(Helpers.getDefaultContractExample().indexOf("\n\n")+2);
+
+var contractSource = localStorage.getItem('contractSource');
+
+if (contractSource && (contractSource.indexOf(shortExample) !== -1 || contractSource === "")) {
+    localStorage.setItem('contractSource', Helpers.getDefaultContractExample());
 }
  
 

--- a/app/client/lib/helpers/helperFunctions.js
+++ b/app/client/lib/helpers/helperFunctions.js
@@ -18,7 +18,7 @@ Get the default contract example
 @method getDefaultContractExample
 **/
 Helpers.getDefaultContractExample = function() {
-    solcVersion = mist.solidity.version || '0.4.7';
+    solcVersion = mist.solidity.version || '0.4.6';  // Keep this for now as the Mist-API object will only be availabe from Mist version >= 0.8.9 so that older versions that will query code from wallet.ethereum.org won't use broken example code.
     
     return `pragma solidity ^${solcVersion};\n\ncontract MyContract {\n    /* Constructor */\n    function MyContract() {\n\n    }\n}`;
 }

--- a/app/client/lib/helpers/helperFunctions.js
+++ b/app/client/lib/helpers/helperFunctions.js
@@ -17,10 +17,15 @@ Get the default contract example
 
 @method getDefaultContractExample
 **/
-Helpers.getDefaultContractExample = function() {
-    solcVersion = mist.solidity.version || '0.4.6';  // Keep this for now as the Mist-API object will only be availabe from Mist version >= 0.8.9 so that older versions that will query code from wallet.ethereum.org won't use broken example code.
-    
-    return `pragma solidity ^${solcVersion};\n\ncontract MyContract {\n    /* Constructor */\n    function MyContract() {\n\n    }\n}`;
+Helpers.getDefaultContractExample = function(withoutPragma) {
+    const source = 'contract MyContract {\n    /* Constructor */\n    function MyContract() {\n\n    }\n}';
+
+    if (withoutPragma) {
+        return source;
+    } else {
+        solcVersion = mist.solidity.version || '0.4.6';  // Keep this for now as the Mist-API object will only be availabe from Mist version >= 0.8.9 so that older versions that will query code from wallet.ethereum.org won't use broken example code.
+        return 'pragma solidity ' + solcVersion + ';\n\n' + source;
+    }
 }
 
 /**

--- a/app/client/lib/helpers/helperFunctions.js
+++ b/app/client/lib/helpers/helperFunctions.js
@@ -13,11 +13,15 @@ The Helpers class containing helper functions
 Helpers = {};
 
 /**
-The default contract example
+Get the default contract example
 
-@property defaultContractExample
+@method getDefaultContractExample
 **/
-Helpers.defaultContractExample = 'pragma solidity ^0.4.6;\n\ncontract MyContract {\n    /* Constructor */\n    function MyContract() {\n\n    }\n}';
+Helpers.getDefaultContractExample = function() {
+    solcVersion = mist.solidity.version || '0.4.7';
+    
+    return `pragma solidity ^${solcVersion};\n\ncontract MyContract {\n    /* Constructor */\n    function MyContract() {\n\n    }\n}`;
+}
 
 /**
 Reruns functions reactively, based on an interval. Use it like so:

--- a/app/client/templates/elements/compileContract.js
+++ b/app/client/templates/elements/compileContract.js
@@ -109,7 +109,7 @@ Template['elements_compileContract'].onRendered(function() {
     this.aceEditor.$blockScrolling = Infinity;
     this.aceEditor.focus();
 
-    var defaultCode = localStorage['contractSource'] || Helpers.defaultContractExample;
+    var defaultCode = localStorage['contractSource'] || Helpers.getDefaultContractExample();
     this.aceEditor.setValue(defaultCode);
     this.aceEditor.selection.selectTo(0);
 

--- a/app/client/templates/views/send.js
+++ b/app/client/templates/views/send.js
@@ -596,7 +596,7 @@ Template['views_send'].events({
 
                             addTransactionAfterSend(txHash, amount, selectedAccount.address, to, gasPrice, estimatedGas, data);
 
-                            localStorage.setItem('contractSource', Helpers.defaultContractExample);
+                            localStorage.setItem('contractSource', Helpers.getDefaultContractExample());
                             localStorage.setItem('compiledContracts', null);
                             localStorage.setItem('selectedContract', null);
 
@@ -639,7 +639,7 @@ Template['views_send'].events({
 
                             addTransactionAfterSend(txHash, amount, selectedAccount.address, to, gasPrice, estimatedGas, data);
 
-                            localStorage.setItem('contractSource', Helpers.defaultContractExample);
+                            localStorage.setItem('contractSource', Helpers.getDefaultContractExample());
                             localStorage.setItem('compiledContracts', null);
                             localStorage.setItem('selectedContract', null);
 


### PR DESCRIPTION
The Mist-API object `mist.solidity.version` will be available starting with `0.8.9`.

As current and older versions of Mist will query the wallet code from `wallet.ethereum.org` it will use `0.4.6` as soliditiy version (as currently used in `0.8.8`).