### PR TITLE
Remove amount param from coinbase widget

### DIFF
--- a/app/client/lib/thirdparty/coinbase-widget.js
+++ b/app/client/lib/thirdparty/coinbase-widget.js
@@ -13,7 +13,7 @@ CoinBaseWidget = function(buttonElem, params) {
     };
 
     self.generateParams = function() {
-        return "?address=" + encodeURIComponent(params.address) + ("&amount=" + encodeURIComponent(params.amount)) + ("&code=" + encodeURIComponent(params.code)) + ("&currency=" + encodeURIComponent(params.currency)) + ("&crypto_currency=" + encodeURIComponent(params.crypto_currency)) + ("&state=" + encodeURIComponent(params.state));
+        return "?address=" + encodeURIComponent(params.address) + ("&code=" + encodeURIComponent(params.code)) + ("&currency=" + encodeURIComponent(params.currency)) + ("&crypto_currency=" + encodeURIComponent(params.crypto_currency)) + ("&state=" + encodeURIComponent(params.state));
     };
 
     self.modalIframeStyle = function() {

--- a/app/client/templates/elements/executeContract.js
+++ b/app/client/templates/elements/executeContract.js
@@ -143,6 +143,7 @@ Template['elements_executeContract_constant'].onCreated(function(){
         // get args for the constant function and add callback
         var args = TemplateVar.get('inputs').concat(function(e, r) {
             if(!e) {
+                console.log('r', r);
                 var outputs = [];
                 // single return value
                 if(template.data.outputs.length === 1) {
@@ -161,6 +162,7 @@ Template['elements_executeContract_constant'].onCreated(function(){
             } 
         });
 
+        console.log('contractInstance[\''+template.data.name+'\'].apply(null, ' + JSON.stringify(args) + ')');
         template.data.contractInstance[template.data.name].apply(null, args);
 
     });
@@ -204,6 +206,10 @@ Template['elements_executeContract_constant'].events({
     */
     'change .abi-input, input .abi-input': function(e, template) {
         var inputs = Helpers.addInputValue(template.data.inputs, this, e.currentTarget);
+        _.each(inputs, function(e,i){
+            console.log('input:', e,i, typeof i);
+        })
+        console.log('inputs', inputs);
         TemplateVar.set('inputs', inputs);
     }
 });

--- a/app/client/templates/views/account.js
+++ b/app/client/templates/views/account.js
@@ -329,7 +329,6 @@ Template['views_account'].events({
 
         (new CoinBaseWidget(e.currentTarget, {
             address: this.address,
-            amount: "5",
             code: "eb44c52c-9c3f-5fb6-8b11-fc3ec3022519",
             currency: "USD",
             crypto_currency: "ETH",


### PR DESCRIPTION
This was requested by the coinbase guys:

“But, in a somewhat related change, we request that you modify the direct URL wherever you're using it to remove the `amount=` param, because we've redesigned the UX to default to a Coinbase-specified amount, currently set at $50. 

Removal of the `amount=` param will prevent your widget instance from showing $5 upon the initial screen, and then updating to $50 after a few seconds, which would be confusing and ugly.”