### PR TITLE
Addresses need quotes

### DIFF
--- a/app/client/templates/elements/inputs/json.html
+++ b/app/client/templates/elements/inputs/json.html
@@ -2,5 +2,5 @@
     <h4>
         {{#if name}}{{{toSentence name}}} <em>-</em> {{/if}}<em>{{type}}</em>
     </h4>
-    <textarea name="elements_input_json" cols="20" rows="5" class="abi-input {{class}}" placeholder="['my text', 12345]">{{value}}</textarea>
+    <textarea name="elements_input_json" cols="20" rows="5" class="abi-input {{class}}" placeholder="['my text', 12345, '0x...']">{{value}}</textarea>
 </template>


### PR DESCRIPTION

![screen shot 2017-02-27 at 13 05 29](https://cloud.githubusercontent.com/assets/8081877/23362927/f3632ce8-fcef-11e6-9e2b-460e752cb82e.png)
The interface doesn't specify whether addresses need quotes or not. I'm inferring from https://github.com/ethereum/meteor-dapp-wallet/issues/118 that address parameters need quotes.