### PR TITLE
fixes token selection when sending via the zebra-token-list

### DIFF
--- a/app/client/templates/views/send.html
+++ b/app/client/templates/views/send.html
@@ -1,7 +1,5 @@
 <template name="views_send">
-
-    {{reactiveData}}
-
+    
     <!-- we use a form, which posts into the "dapp-form-helper-iframe" iframe, so that the browser stores inout fields for native autocpmplete -->
     <form class="account-send-form" action="about:blank" target="dapp-form-helper-iframe" autocomplete="on">
             

--- a/app/client/templates/views/send.js
+++ b/app/client/templates/views/send.js
@@ -103,7 +103,7 @@ Template['views_send'].onCreated(function(){
     TemplateVar.set('sendAll', false);
     
     // Deploy contract
-    if(this && this.deployContract) {
+    if(FlowRouter.getRouteName() === 'deployContract') {
         TemplateVar.set('selectedAction', 'deploy-contract');
         TemplateVar.set('selectedToken', 'ether');
 

--- a/app/client/templates/views/send.js
+++ b/app/client/templates/views/send.js
@@ -101,38 +101,49 @@ Template['views_send'].onCreated(function(){
     TemplateVar.set('amount', '0');
     TemplateVar.set('estimatedGas', 300000);
     TemplateVar.set('sendAll', false);
+    
+    // Deploy contract
+    if(this && this.deployContract) {
+        TemplateVar.set('selectedAction', 'deploy-contract');
+        TemplateVar.set('selectedToken', 'ether');
 
+    // Send funds
+    } else {
+        TemplateVar.set('selectedAction', 'send-funds');
+        TemplateVar.set('selectedToken', FlowRouter.getParam('token') || 'ether');
+    }
+    
     // check if we are still on the correct chain
     Helpers.checkChain(function(error) {
         if(error && (EthAccounts.find().count() > 0)) {
             checkForOriginalWallet();
         }
     });
-
+    
     // change the token type when the account is changed
     template.autorun(function(c){
         var address = TemplateVar.getFrom('.dapp-select-account.send-from', 'value');
-
-        if(!c.firstRun) {
+        
+        if(!c.firstRun && FlowRouter.getParam('from') !== address) {
             TemplateVar.set('selectedToken', 'ether');
         }
     });
 
-
+    
     // check daily limit again, when the account was switched
     template.autorun(function(c){
         var address = TemplateVar.getFrom('.dapp-select-account.send-from', 'value'),
             amount = TemplateVar.get('amount') || '0';
-
+    
         if(!c.firstRun) {
             checkOverDailyLimit(address, amount, template);
         }
     });
-
+    
     // change the amount when the currency unit is changed
     template.autorun(function(c){
         var unit = EthTools.getUnit();
-
+    
         if(!c.firstRun && TemplateVar.get('selectedToken') === 'ether') {
             TemplateVar.set('amount', EthTools.toWei(template.find('input[name="amount"]').value.replace(',','.'), unit));
         }
@@ -207,24 +218,6 @@ Template['views_send'].onRendered(function(){
 
 
 Template['views_send'].helpers({
-    /**
-    React on the template data context
-
-    @method (reactiveData)
-    */
-    'reactiveData': function(deployContract){
-
-        // Deploy contract
-        if(this && this.deployContract) {
-            TemplateVar.set('selectedAction', 'deploy-contract');
-            TemplateVar.set('selectedToken', 'ether');
-
-        // Send funds
-        } else {
-            TemplateVar.set('selectedAction', 'send-funds');
-            TemplateVar.set('selectedToken', FlowRouter.getParam('token') || 'ether');
-        }
-    },
     /**
     Get the current selected account
 


### PR DESCRIPTION
Fixes a bug a reddit user reported yesterday:

When selecting an account and instructing "send" via the zebra-token-list Ether will be selected instead of the token.

Also calling `{{reactiveData}}` changed the TemplateVars, thus rerun all `template.autorun()` instances, which might break the `if(!c.firstRun)` conditions.