### PR TITLE
fix gas calculation of stored contracts in localStorage

### DIFF
--- a/app/client/templates/elements/compileContract.js
+++ b/app/client/templates/elements/compileContract.js
@@ -162,7 +162,7 @@ Template['elements_compileContract'].onRendered(function() {
 
                         return {
                             name: name,
-                            bytecode: contract.bytecode,
+                            bytecode: '0x' + contract.bytecode.replace(/^0x/, ''),
                             jsonInterface: jsonInterface,
                             constructorInputs: constructor.inputs
                         };


### PR DESCRIPTION
When deploying a contract that was stored in localStorage (earlier last sessions) not editing it prior deploying will cause the fee calculation to be skipped.

How to reproduce:
1. Chose to deploy a new contract and paste some bigger contract like https://gist.github.com/luclu/5fe236b6bc03ff1c3a9932a1d3727d8b
1. Restart Ethereum Wallet
1. Try to deploy stored contract without editing it (fees should be miscalculated)

This PR will add the `0x` to the data, which will play nice with the stricter input validation from https://github.com/ethereum/mist/pull/2092. (which should be updated accordingly).