### PR TITLE
initialize send view correctly when switching from deploy view

### DIFF
--- a/app/client/templates/views/send.js
+++ b/app/client/templates/views/send.js
@@ -160,6 +160,15 @@ Template['views_send'].onRendered(function(){
         TemplateVar.setTo('select[name="dapp-select-account"].send-from', 'value', FlowRouter.getParam('from').toLowerCase());
 
 
+    // initialize send view correctly when directly switching from deploy view
+    template.autorun(function(c){
+        if(FlowRouter.getRouteName() === 'send') {
+            TemplateVar.set('selectedAction', 'send');
+            TemplateVar.setTo('.dapp-data-textarea', 'value', ''); 
+        }
+    });
+    
+
     // ->> GAS PRICE ESTIMATION
     template.autorun(function(c){
         var address = TemplateVar.getFrom('.dapp-select-account.send-from', 'value'),


### PR DESCRIPTION
Fixes a bug where when directly switching from deploy view to the send view, the data field will still be populated.
