### PR TITLE
Add ES6 support; correction to fr translation

### DIFF
--- a/app/.meteor/packages
+++ b/app/.meteor/packages
@@ -48,3 +48,4 @@ jrudio:bluebird
 tap:i18n-bundler
 numeral:numeral
 numeral:languages
+ecmascript

--- a/app/i18n/wallet.fr.i18n.json
+++ b/app/i18n/wallet.fr.i18n.json
@@ -102,17 +102,17 @@
                 }
             }
         },
-        "events": {     
-            "eventInfoTitle": "Événement",      
-            "latest": "Derniers événements",      
-            "filter": "Filtrer les événements",      
-            "transactionHash": "Hash de transaction",      
-            "block": "Bloc",       
-            "originContract": "Contrat d'origine",        
-            "logIndex": "Indice de log",        
-            "transactionIndex": "Indice de transaction",        
-            "returnValues": "Valeurs de retour",        
-            "eventName": "Nom de l'événement"      
+        "events": {
+            "eventInfoTitle": "Événement",
+            "latest": "Derniers événements",
+            "filter": "Filtrer les événements",
+            "transactionHash": "Hash de transaction",
+            "block": "Bloc",
+            "originContract": "Contrat d'origine",
+            "logIndex": "Indice de log",
+            "transactionIndex": "Indice de transaction",
+            "returnValues": "Valeurs de retour",
+            "eventName": "Nom de l'événement"
         },
         "transactions": {
             "transactionInfoTitle": "Transaction",
@@ -126,7 +126,7 @@
             "amount": "Montant",
             "gasPrice": "Prix du gaz",
             "perMillionGas": "par millions de gaz",
-            "gasUsed": "Gaz utilisé", 
+            "gasUsed": "Gaz utilisé",
             "feePaid": "Commission payée",
             "data": "Données envoyées",
             "deployedData": "Données déployées",
@@ -145,7 +145,7 @@
             },
             "error": {
                 "noDataDeployed": "Aucune donnée n'est déployée à l'adresse du contrat !",
-                "outOfGas": "La transaction depuis __from__ à __to__ n'a pas pu s'exécuter correctement."  
+                "outOfGas": "La transaction depuis __from__ à __to__ n'a pas pu s'exécuter correctement."
             },
             "types": {
                 "executeContract": "Exécution du contrat",
@@ -168,7 +168,7 @@
                 },
                 "outgoingTransaction": {
                     "title": "Paiement envoyé",
-                    "text": "Vous avez envoyé __amount__ depuis __from__ à __to__."    
+                    "text": "Vous avez envoyé __amount__ depuis __from__ à __to__."
                 },
                 "pendingConfirmation": {
                     "title": "Confirmation requise",
@@ -274,7 +274,7 @@
             "title": "<strong>Jetons</strong> que vous suivez",
             "subTitle": "Jetons ajoutés",
             "admin": "__name__ (page d'administration)",
-            "description": "Les jetons sont des devises et autres fongibles construits sur la plateforme Expanse. Pour que les comptes puissent voir et envoyer des jetons, vous devez ajouter l'adresse de leur contrat à cette liste. Vous pouvez créer votre propre jeton simplement en modifiant <a href=\"https://ethereum.org/token#the-code\" target=\"_blank\">cet exemple d'un contrat de jeton</a> ou en en apprenant plus sur <a href=\"https://www.Ethereum.org/token\" target=\"_blank\">les jetons dans Ethereum</a>.",
+            "description": "Les jetons sont des devises et autres fongibles construits sur la plateforme Ethereum. Pour que les comptes puissent voir et envoyer des jetons, vous devez ajouter l'adresse de leur contrat à cette liste. Vous pouvez créer votre propre jeton simplement en modifiant <a href=\"https://ethereum.org/token#the-code\" target=\"_blank\">cet exemple d'un contrat de jeton</a> ou en en apprenant plus sur <a href=\"https://www.Ethereum.org/token\" target=\"_blank\">les jetons dans Ethereum</a>.",
             "deleteToken": "Voulez-vous supprimer le jeton <strong>__token__</strong> de votre liste ?",
             "addedToken": "__token__ ajouté à votre liste",
             "editedToken": "Jeton __token__ modifié",


### PR DESCRIPTION
Makes a small correction to french translation, line 277: Expanse -> Ethereum (atom also killed some trailing whitespace)

Adds ecmascript to meteor packages as a ES6 template literal is used [here](https://github.com/ethereum/meteor-dapp-wallet/blob/develop/app/client/index.js#L27) resulting in build failure  

````
Bundling Meteor app...
Failed to execute "meteor build ../build --directory", exit code of #1
 Errors prevented bundling:
While minifying app code:

/home/xocel/.meteor/packages/standard-minifier-js/.1.0.6.q82nzk++os+web.browser+web.cordova/plugin.minifyStdJS.os/npm/node_modules/meteor/minifier-js/node_modules/uglify-js/lib/parse.js:196:18:
Unexpected character '`'
````

Noticed ES6 has been added to related projects, I assume its intended to be added here also. 
