### PR TITLE
Temporarily removing ES6 support: fixing indexeddb driver bug

### DIFF
--- a/app/.meteor/packages
+++ b/app/.meteor/packages
@@ -48,5 +48,4 @@ jrudio:bluebird
 tap:i18n-bundler
 numeral:numeral
 numeral:languages
-ecmascript
 hashanp:geopattern

--- a/app/client/index.js
+++ b/app/client/index.js
@@ -24,7 +24,7 @@ Meteor.startup(function() {
             try {
                 numeral.language(lang);
             } catch (err) {
-                console.warn(`numeral.js couldn't set number formating: ${err.message}`);
+                console.warn('numeral.js couldn\'t set number formating: ', err.message);
             }
             EthTools.setLocale(lang);
         }
@@ -43,7 +43,7 @@ Meteor.startup(function() {
                     symbol: '🦄',
                     balances: {},
                     decimals: 0
-                }});    
+                }});
             }, 5000);
         }
     });


### PR DESCRIPTION
`ecmascript` package introduced an indexeddb driver failure to load. 

This PR reverts `ecmascript` package, and the wallet is stable again.