### PR TITLE
Fix stuck creating wallets on LES

### DIFF
--- a/app/.meteor/versions
+++ b/app/.meteor/versions
@@ -33,7 +33,7 @@ ecmascript-runtime@0.2.10
 ejson@1.0.11
 ethereum:accounts@0.4.0
 ethereum:blocks@0.3.2
-ethereum:dapp-styles@0.5.7
+ethereum:dapp-styles@0.5.9
 ethereum:elements@0.7.17
 ethereum:tools@0.7.0
 ethereum:web3@0.15.3

--- a/app/.meteor/versions
+++ b/app/.meteor/versions
@@ -33,7 +33,7 @@ ecmascript-runtime@0.2.10
 ejson@1.0.11
 ethereum:accounts@0.4.0
 ethereum:blocks@0.3.2
-ethereum:dapp-styles@0.5.9
+ethereum:dapp-styles@0.5.7
 ethereum:elements@0.7.17
 ethereum:tools@0.7.0
 ethereum:web3@0.15.3

--- a/app/client/templates/elements/account.js
+++ b/app/client/templates/elements/account.js
@@ -93,7 +93,12 @@ Template['elements_account'].helpers({
     @method (creating)
     */
     'creating': function(){
-        return (!this.address || this.imported || (blocksForConfirmation >= EthBlocks.latest.number - (this.creationBlock - 1) && EthBlocks.latest.number - (this.creationBlock - 1) >= 0));
+        var noAddress = !this.address;
+        var isImported = this.imported;
+        var belowReorgThreshold = (blocksForConfirmation >= EthBlocks.latest.number - (this.creationBlock - 1));
+        var blockNumberCheck = EthBlocks.latest.number - (this.creationBlock - 1) >= 0;
+
+        return (noAddress || isImported || (belowReorgThreshold && blockNumberCheck));
     },
     /**
     Returns the confirmations
@@ -138,7 +143,7 @@ Template['elements_account'].helpers({
 Template['elements_account'].events({
     /**
     Field test the speed wallet is rendered
-    
+
     @event click button.show-data
     */
     'click .wallet-box': function(e){


### PR DESCRIPTION
This PR fixes the creation of wallet contracts while using the Light Client.

It gets wallets that has transaction hash and does not have addresses and performs a getTransactionReceipt, trying to find that particular address.

It'll only work after https://github.com/ethereum/mist/pull/3265 has been released.