### PR TITLE
Adds method visibility in placeholder contract

### DIFF
--- a/app/client/lib/helpers/helperFunctions.js
+++ b/app/client/lib/helpers/helperFunctions.js
@@ -18,7 +18,7 @@ Get the default contract example
 @method getDefaultContractExample
 **/
 Helpers.getDefaultContractExample = function(withoutPragma) {
-    var source = 'contract MyContract {\n    /* Constructor */\n    function MyContract() {\n\n    }\n}';
+    var source = 'contract MyContract {\n    /* Constructor */\n    function MyContract() public {\n\n    }\n}';
 
     if (withoutPragma) {
         return source;


### PR DESCRIPTION
From Solidity compiler 0.4.18 on, a warning will be fired when a method does not specify its visibility.

This PR adds `public` identifier to the constructor method.