### PR TITLE
Quick i18n language changes

### DIFF
--- a/app/i18n/wallet.en.i18n.json
+++ b/app/i18n/wallet.en.i18n.json
@@ -222,7 +222,7 @@
                 }
             },
             "error": {
-                "emptySignees": "You didn't provided all owners.",
+                "emptySignees": "You didn't provide all owners.",
                 "alreadyExists": "Wallet contract already exists.",
                 "stubHasNoOrigWalletAddress": "Your stub contract has no original account address set.  Please restart your App!",
                 "contractsCantBeOwners": "Contracts can't be owners.",
@@ -270,7 +270,7 @@
                 "sendFee": "This is the most amount of money that might be used to process this transaction. Your transaction will be mined <strong>__timetext__</strong>.",
                 "noCodeInRecipient": "The recipient account is not a contract, so you can't execute anything. <strong> Put a contract address on the 'TO' field. </strong>",
                 "addData": "You can add extra data to send along with your transaction. If you don't know what this is then <strong>don't touch it or bad things may happen</strong>.",
-                "dataNotExecutable": "The data seems not to be executabe, that means this transaction will use all the gas you provide.",
+                "dataNotExecutable": "It seems this transaction will fail. If you submit it, it may consume all the gas you provide.",
                 "cantEstimateGas": "We can't estimate your gas usage properly, as you need at least 1 Ether in your account.",
                 "estimatedGas": "Estimated required gas",
                 "timeTexts": {

--- a/app/i18n/wallet.pt.i18n.json
+++ b/app/i18n/wallet.pt.i18n.json
@@ -266,7 +266,7 @@
                 "sendFee": "Essa é a taxa máxima que será paga pela transação, você irá receber qualquer troco que for gerado automaticamente. Sua transação irá demorar <strong>__timetext__</strong> para ser incluída no blockchain.",
                 "noCodeInRecipient": "The recipient account is not a contract, so you can't execute anything. <strong> Put a contract address on the 'TO' field. </strong>",
                 "addData": "You can add extra data to send along with your transaction. If you leave the \"to\" field empty it will try to deploy a contract from your data.",
-                "dataNotExecutable": "The data seems not to be executabe, that means this transaction will use all the gas you provide.",
+                "dataNotExecutable": "It seems this transaction will fail. If you submit it, it may consume all the gas you provide.",
                 "cantEstimateGas": "We can't estimate your gas usage properly, as you need at least 1 ether in your account.",
                 "estimatedGas": "Estimated required gas",
                 "timeTexts": {


### PR DESCRIPTION
Message contained a typo; changed the message to align with ethereum/mist error message.