### PR TITLE
Adding config file for pullapprove service

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -9,4 +9,5 @@ groups:
     - evertonfraga
     - frozeman
     - marcgarreau
+    - PhilippLgh
     - ryanio

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,12 @@
+version: 2
+groups:
+  code-review:
+    required: 2
+    reset_on_push:
+      enabled: true
+    users:
+    - alexvandesande
+    - evertonfraga
+    - frozeman
+    - marcgarreau
+    - ryanio

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -11,3 +11,4 @@ groups:
     - marcgarreau
     - PhilippLgh
     - ryanio
+


### PR DESCRIPTION
We're about to enforce at least two reviews per PR. The [Pull Approve](https://pullapprove.com) service helps us get there.