### PR TITLE
Hide gas section if isMist

### DIFF
--- a/app/client/templates/views/send.html
+++ b/app/client/templates/views/send.html
@@ -126,6 +126,7 @@
         {{/if}}
 
 
+        {{#unless isMist}}
         <!-- fee -->
         <div class="row clear">
             <div class="col col-7 mobile-full">
@@ -172,6 +173,7 @@
 
             <div class="dapp-clear-fix"></div>
         </div>
+        {{/unless}}
 
         <hr>
 


### PR DESCRIPTION
Since we are now handling gas inside [the new SendTx window in Mist](https://github.com/ethereum/mist/pull/4070), this PR hides the gas section on the Send tab if `isMist`